### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/csi/build.gradle.kts
+++ b/csi/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     group = "com.kape.android"
-    version = "1.3.1"
+    version = "1.3.2"
 
     // Enable the default target hierarchy.
     // It's a template for all possible targets and their shared source sets hardcoded in the


### PR DESCRIPTION
## Summary

As per title, it bumps the version to `1.3.2`.

## Sanity Tests

N/A